### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/code/src/Attendee/Attendee.cs
+++ b/code/src/Attendee/Attendee.cs
@@ -9,7 +9,11 @@ namespace Attendees
     {
         public void WriteToDirectory(ZipArchiveEntry entry, string destDirectory)
         {
-            string destFileName = Path.Combine(destDirectory, entry.FullName);
+            string destFileName = Path.GetFullPath(Path.Combine(destDirectory, entry.FullName));
+            string fullDestDirPath = Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar);
+            if (!destFileName.StartsWith(fullDestDirPath)) {
+                throw new InvalidOperationException("Entry is outside the target dir: " + destFileName);
+            }
             entry.ExtractToFile(destFileName);
         }
         


### PR DESCRIPTION
Potential fix for [https://github.com/PedroManuelAtienzaHuerta/skills-secure-repository-supply-chain/security/code-scanning/1](https://github.com/PedroManuelAtienzaHuerta/skills-secure-repository-supply-chain/security/code-scanning/1)

To fix the vulnerability, we need to ensure that the output file path constructed from the archive entry is strictly within the intended destination directory. This involves three steps:
1. Use `Path.GetFullPath` on the combined path to resolve any directory traversal elements.
2. Use `Path.GetFullPath` on the destination directory (with a trailing separator) to get its canonical form.
3. Check that the resolved output file path starts with the resolved destination directory path. If not, throw an exception to abort extraction.

These changes should be made in the `WriteToDirectory` method in `code/src/Attendee/Attendee.cs`. No new methods are needed, but we must add the validation logic before calling `ExtractToFile`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
